### PR TITLE
TASK: Add Rule to use $resetSingletonInstance property

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         NimutTestingFrameworkSetList::NIMUT_TESTING_FRAMEWORK_TO_TYPO3_TESTING_FRAMEWORK,
         TYPO3TestingFrameworkSetList::TYPO3_TESTING_FRAMEWORK_7,
+        TYPO3TestingFrameworkSetList::RESET_SINGLETON_PROPERTY_INSTEAD_OF_TEARDOWN,
     ]);
 };
 ```

--- a/config/sets/typo3-testingframework/resetSingletonPropertyInsteadOfTeardown.php
+++ b/config/sets/typo3-testingframework/resetSingletonPropertyInsteadOfTeardown.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+};

--- a/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/Fixture/resetSingletonPropertyInsteadOfTeardown.php.inc
+++ b/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/Fixture/resetSingletonPropertyInsteadOfTeardown.php.inc
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Ssch\Typo3RectorTestingFramework\Tests\Set\TYPO3TestingFrameworkSetList\TestingFramework7\Fixture;
+
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ResetSingletonInsteadOfTeardownTestCase extends UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        echo "Not related function call";
+        $this->resetSingletonInstances = true;
+    }
+}
+
+?>
+-----
+<?php
+declare(strict_types=1);
+
+namespace Ssch\Typo3RectorTestingFramework\Tests\Set\TYPO3TestingFrameworkSetList\TestingFramework7\Fixture;
+
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ResetSingletonInsteadOfTeardownTestCase extends UnitTestCase
+{
+    protected bool $resetSingletonInstances = true;
+
+    protected function tearDown(): void
+    {
+        echo "Not related function call";
+    }
+}
+
+?>

--- a/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/Fixture/resetSingletonPropertyInsteadOfTeardown.php.inc
+++ b/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/Fixture/resetSingletonPropertyInsteadOfTeardown.php.inc
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3RectorTestingFramework\Tests\Set\TYPO3TestingFrameworkSetList\TestingFramework7\Fixture;
 
-use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class ResetSingletonInsteadOfTeardownTestCase extends UnitTestCase
@@ -22,7 +21,6 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3RectorTestingFramework\Tests\Set\TYPO3TestingFrameworkSetList\TestingFramework7\Fixture;
 
-use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class ResetSingletonInsteadOfTeardownTestCase extends UnitTestCase

--- a/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/config/configured_rule.php
+++ b/rules-tests/Set/TYPO3TestingFrameworkSetList/TestingFramework7/config/configured_rule.php
@@ -8,5 +8,6 @@ use Ssch\Typo3RectorTestingFramework\Set\TYPO3TestingFrameworkSetList;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         TYPO3TestingFrameworkSetList::TYPO3_TESTING_FRAMEWORK_7,
+        TYPO3TestingFrameworkSetList::RESET_SINGLETON_PROPERTY_INSTEAD_OF_TEARDOWN,
     ]);
 };

--- a/src/Set/TYPO3TestingFrameworkSetList.php
+++ b/src/Set/TYPO3TestingFrameworkSetList.php
@@ -7,4 +7,5 @@ namespace Ssch\Typo3RectorTestingFramework\Set;
 final class TYPO3TestingFrameworkSetList
 {
     public const TYPO3_TESTING_FRAMEWORK_7 = __DIR__ . '/../../config/sets/typo3-testingframework/typo3-testingframework-7.php';
+    public const RESET_SINGLETON_PROPERTY_INSTEAD_OF_TEARDOWN = __DIR__ . '/../../config/sets/typo3-testingframework/resetSingletonPropertyInsteadOfTeardown.php';
 }


### PR DESCRIPTION
I have added a test that fails, as there is no real implementation yet.

I haven't done rector for quite a while, so currently, not able to graps what I need to do to get it to work. But will try to figure it out. 

I know that I need the 

```php
 new AddPropertyTypeDeclaration(
    'TYPO3\TestingFramework\Core\Unit\UnitTestCase',
    'resetSingletonInstances',
    new BooleanType()
),
```

in some constellation or another. But it should only be done when the value is set in the teardown. 